### PR TITLE
Update SinaStockHandler.java

### DIFF
--- a/src/main/java/handler/SinaStockHandler.java
+++ b/src/main/java/handler/SinaStockHandler.java
@@ -123,9 +123,7 @@ public class SinaStockHandler extends StockRefreshHandler {
                 String bondStr = bean.getBonds();
                 if (StringUtils.isNotEmpty(bondStr)) {
                     BigDecimal bondDec = new BigDecimal(bondStr);
-                    BigDecimal incomeDec = incomeDiff.divide(costPriceDec, 5, RoundingMode.HALF_UP)
-                            .multiply(bondDec)
-                            .multiply(now)
+                    BigDecimal incomeDec = incomeDiff.multiply(bondDec)
                             .setScale(2, RoundingMode.HALF_UP);
                     bean.setIncome(incomeDec.toString());
                 }


### PR DESCRIPTION
修复成本价过低时收益金额不正确的问题,触发问题的相关数据：持仓成本0.007，现价1.740，持仓量200